### PR TITLE
Fixed kernel leakage in case of failure

### DIFF
--- a/tensorflow/core/framework/op_segment.cc
+++ b/tensorflow/core/framework/op_segment.cc
@@ -41,6 +41,8 @@ Status OpSegment::FindOrCreate(const string& session_handle,
     mutex_lock l(mu_);
     auto item = gtl::FindPtrOrNull(sessions_, session_handle);
     if (item == nullptr) {
+      delete *kernel;
+      *kenrel = nullptr;
       return errors::NotFound("Session ", session_handle, " is not found.");
     }
     OpKernel** p_kernel = &(item->name_kernel[node_name]);


### PR DESCRIPTION
OpSegment::FindOrCreate may leak kernel object in case of invalid session_handle.
